### PR TITLE
Read cache filesystem for local manual testing

### DIFF
--- a/src/columnstore/columnstore_filesystem.cpp
+++ b/src/columnstore/columnstore_filesystem.cpp
@@ -1,0 +1,108 @@
+#include "columnstore/columnstore_filesystem.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/uuid.hpp"
+#include "duckdb/common/vector.hpp"
+#include "pgmooncake_guc.hpp"
+#include "utils/scope_guard.h"
+
+namespace duckdb {
+
+namespace {
+// Get local cache filename for the given [remote_file].
+string GetLocalCacheFile(const string &remote_file) {
+    const string fname = StringUtil::GetFileName(remote_file);
+    return x_mooncake_local_cache + fname;
+}
+
+// Columnstore read cache filesystem name.
+constexpr const char *const kColumnstoreReadCacheFileSystemName = "ColumnstoreReadCacheFileSystem";
+} // namespace
+
+ColumnstoreReadCacheFileSystem::ColumnstoreReadCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p)
+    : internal_filesystem(std::move(internal_filesystem_p)) {
+    D_ASSERT(internal_filesystem);
+    D_ASSERT(internal_filesystem->GetName() != kColumnstoreReadCacheFileSystemName);
+}
+
+std::string ColumnstoreReadCacheFileSystem::GetName() const {
+    return kColumnstoreReadCacheFileSystemName;
+}
+
+unique_ptr<FileHandle> ColumnstoreReadCacheFileSystem::OpenFile(const string &path, FileOpenFlags flags,
+                                                                optional_ptr<FileOpener> opener) {
+    // TODO(hjiang): If open for read, aggressively read the whole file synchronously and cache on local filesystem.
+    // This implementation is initial and coarse, there're a few things to consider and optimize.
+    // Reference: https://github.com/Mooncake-Labs/pg_mooncake/discussions/69#discussioncomment-11760100
+    //
+    // TODO(hjiang): Always enable caching for testing, revert before PR.
+    // if (flags.OpenForReading() && IsRemoteFile(path) && mooncake_enable_local_cache) {
+    if (flags.OpenForReading() && StringUtil::StartsWith(path, "/usr/local/pgsql/data")) {
+        if (local_filesystem == nullptr) {
+            local_filesystem = FileSystem::CreateLocal();
+        }
+        CacheRemoteFileIfEnabled(path, flags, opener);
+        const string local_cache_file = GetLocalCacheFile(path);
+        return local_filesystem->OpenFile(local_cache_file, flags, opener);
+    }
+
+    return internal_filesystem->OpenFile(path, flags, opener);
+}
+
+void ColumnstoreReadCacheFileSystem::CacheRemoteFileIfEnabled(const string &remote_path, const FileOpenFlags &flags,
+                                                              optional_ptr<FileOpener> opener) {
+    // Check whether cache file already exists, return if already exists.
+    const string local_cache_file = GetLocalCacheFile(remote_path);
+    if (local_filesystem->FileExists(local_cache_file)) {
+        return;
+    }
+
+    // Read the whole content from remote file.
+    vector<char> file_content;
+    {
+        auto file_handle = internal_filesystem->OpenFile(remote_path, flags, opener);
+        SCOPE_EXIT {
+            file_handle->Close();
+        };
+        const int64_t file_size = internal_filesystem->GetFileSize(*file_handle);
+        // TODO(hjiang): It's better to use string and leverage resize without initialization.
+        // Reference for abseil implementation:
+        // https://github.com/abseil/abseil-cpp/blob/master/absl/strings/internal/resize_uninitialized.h
+        file_content = vector<char>(file_size, '\0');
+        internal_filesystem->Read(*file_handle, file_content.data(), file_size, /*location=*/0);
+    }
+
+    // Write the whole content into local cache file.
+    const auto fname = StringUtil::GetFileName(remote_path);
+    const auto local_temp_file =
+        StringUtil::Format("%s%s.%s", x_mooncake_local_cache, fname, UUID::ToString(UUID::GenerateRandomUUID()));
+    {
+        auto file_handle = local_filesystem->OpenFile(
+            local_temp_file, FileOpenFlags::FILE_FLAGS_WRITE | FileOpenFlags::FILE_FLAGS_FILE_CREATE_NEW, opener);
+        SCOPE_EXIT {
+            file_handle->Close();
+        };
+        local_filesystem->Write(*file_handle, file_content.data(), file_content.size(), /*location=*/0);
+        file_handle->Sync();
+    }
+
+    // We could have multiple thread caching to the same file, cache to a temporary file, then atomically swap to
+    // destination cache file.
+    //
+    // TODO(hjiang): We could leave temporary file on local filesystem, which we could cleanup at instance setup;
+    // it will handled in the followup PR.
+    local_filesystem->MoveFile(/*source=*/local_temp_file, /*target=*/local_cache_file);
+}
+
+unique_ptr<FileSystem> WrapColumnstoreReadCacheFileSystem(unique_ptr<FileSystem> internal_filesystem) {
+    // We don't want recursive read-cache wrapper.
+    if (internal_filesystem->GetName() == kColumnstoreReadCacheFileSystemName) {
+        return internal_filesystem;
+    }
+    // TODO(hjiang): Always enable for testing purpose, revert before PR.
+    // if (mooncake_enable_local_cache) {
+    //     return make_uniq<ColumnstoreReadCacheFileSystem>(std::move(internal_filesystem));
+    // }
+    return make_uniq<ColumnstoreReadCacheFileSystem>(std::move(internal_filesystem));
+}
+
+} // namespace duckdb

--- a/src/columnstore/columnstore_filesystem.hpp
+++ b/src/columnstore/columnstore_filesystem.hpp
@@ -1,0 +1,145 @@
+// Columnstore read cache filesystem implements read cache to optimize query performance.
+
+#pragma once
+
+#include <utility>
+
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/local_file_system.hpp"
+#include "duckdb/common/unique_ptr.hpp"
+
+namespace duckdb {
+
+class ColumnstoreReadCacheFileSystem : public FileSystem {
+public:
+    ColumnstoreReadCacheFileSystem(unique_ptr<FileSystem> internal_filesystem_p);
+    std::string GetName() const override;
+
+    // Open and read with read cache enabled if specified.
+    unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
+                                    optional_ptr<FileOpener> opener = nullptr) override;
+
+    // For other API calls, delegate to [internal_filesystem] to handle.
+    unique_ptr<FileHandle> OpenCompressedFile(unique_ptr<FileHandle> handle, bool write) override {
+        return internal_filesystem->OpenCompressedFile(std::move(handle), write);
+    }
+    void Read(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
+        internal_filesystem->Read(handle, buffer, nr_bytes, location);
+    }
+    int64_t Read(FileHandle &handle, void *buffer, int64_t nr_bytes) override {
+        return internal_filesystem->Read(handle, buffer, nr_bytes);
+    }
+    void Write(FileHandle &handle, void *buffer, int64_t nr_bytes, idx_t location) override {
+        internal_filesystem->Write(handle, buffer, nr_bytes, location);
+    }
+    int64_t Write(FileHandle &handle, void *buffer, int64_t nr_bytes) override {
+        return internal_filesystem->Write(handle, buffer, nr_bytes);
+    }
+    bool Trim(FileHandle &handle, idx_t offset_bytes, idx_t length_bytes) override {
+        return internal_filesystem->Trim(handle, offset_bytes, length_bytes);
+    }
+    int64_t GetFileSize(FileHandle &handle) {
+        return internal_filesystem->GetFileSize(handle);
+    }
+    time_t GetLastModifiedTime(FileHandle &handle) override {
+        return internal_filesystem->GetLastModifiedTime(handle);
+    }
+    FileType GetFileType(FileHandle &handle) override {
+        return internal_filesystem->GetFileType(handle);
+    }
+    void Truncate(FileHandle &handle, int64_t new_size) override {
+        return internal_filesystem->Truncate(handle, new_size);
+    }
+    bool DirectoryExists(const string &directory, optional_ptr<FileOpener> opener = nullptr) override {
+        return internal_filesystem->DirectoryExists(directory, opener);
+    }
+    void CreateDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr) override {
+        internal_filesystem->CreateDirectory(directory, opener);
+    }
+    void RemoveDirectory(const string &directory, optional_ptr<FileOpener> opener = nullptr) override {
+        internal_filesystem->RemoveDirectory(directory, opener);
+    }
+    bool ListFiles(const string &directory, const std::function<void(const string &, bool)> &callback,
+                   FileOpener *opener = nullptr) override {
+        return internal_filesystem->ListFiles(directory, callback, opener);
+    }
+    void MoveFile(const string &source, const string &target, optional_ptr<FileOpener> opener = nullptr) override {
+        internal_filesystem->MoveFile(source, target, opener);
+    }
+    bool FileExists(const string &filename, optional_ptr<FileOpener> opener = nullptr) override {
+        return internal_filesystem->FileExists(filename, opener);
+    }
+    bool IsPipe(const string &filename, optional_ptr<FileOpener> opener = nullptr) override {
+        return internal_filesystem->IsPipe(filename, opener);
+    }
+    void RemoveFile(const string &filename, optional_ptr<FileOpener> opener = nullptr) override {
+        internal_filesystem->RemoveFile(filename, opener);
+    }
+    void FileSync(FileHandle &handle) override {
+        internal_filesystem->FileSync(handle);
+    }
+    string GetHomeDirectory() override {
+        return internal_filesystem->GetHomeDirectory();
+    }
+    string ExpandPath(const string &path) override {
+        return internal_filesystem->ExpandPath(path);
+    }
+    string PathSeparator(const string &path) override {
+        return internal_filesystem->PathSeparator(path);
+    }
+    vector<string> Glob(const string &path, FileOpener *opener = nullptr) override {
+        return internal_filesystem->Glob(path, opener);
+    }
+    void RegisterSubSystem(unique_ptr<FileSystem> sub_fs) override {
+        internal_filesystem->RegisterSubSystem(std::move(sub_fs));
+    }
+    void RegisterSubSystem(FileCompressionType compression_type, unique_ptr<FileSystem> fs) override {
+        internal_filesystem->RegisterSubSystem(compression_type, std::move(fs));
+    }
+    void UnregisterSubSystem(const string &name) override {
+        internal_filesystem->UnregisterSubSystem(name);
+    }
+    vector<string> ListSubSystems() override {
+        return internal_filesystem->ListSubSystems();
+    }
+    bool CanHandleFile(const string &fpath) override {
+        return internal_filesystem->CanHandleFile(fpath);
+    }
+    void Seek(FileHandle &handle, idx_t location) override {
+        internal_filesystem->Seek(handle, location);
+    }
+    void Reset(FileHandle &handle) override {
+        internal_filesystem->Reset(handle);
+    }
+    idx_t SeekPosition(FileHandle &handle) override {
+        return internal_filesystem->SeekPosition(handle);
+    }
+    bool IsManuallySet() override {
+        return internal_filesystem->IsManuallySet();
+    }
+    bool CanSeek() override {
+        return internal_filesystem->CanSeek();
+    }
+    bool OnDiskFile(FileHandle &handle) override {
+        return internal_filesystem->OnDiskFile(handle);
+    }
+    void SetDisabledFileSystems(const vector<string> &names) override {
+        internal_filesystem->SetDisabledFileSystems(names);
+    }
+
+private:
+    // Cache the whole file specified by the given [path], which is a remote file.
+    // If read and write fails, nothing happens.
+    void CacheRemoteFileIfEnabled(const string &path, const FileOpenFlags &flags, optional_ptr<FileOpener> opener);
+
+private:
+    // Used to access local cache files.
+    unique_ptr<FileSystem> local_filesystem;
+    // Used to access remote files.
+    unique_ptr<FileSystem> internal_filesystem;
+};
+
+// Wrap the given [internal_filesystem] with column store read cache filesystem if possible.
+unique_ptr<FileSystem> WrapColumnstoreReadCacheFileSystem(unique_ptr<FileSystem> internal_filesystem);
+
+} // namespace duckdb

--- a/src/columnstore/columnstore_table.cpp
+++ b/src/columnstore/columnstore_table.cpp
@@ -17,12 +17,6 @@ public:
 public:
     unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
                                     optional_ptr<FileOpener> opener = nullptr) override {
-        if (IsRemoteFile(path) && mooncake_enable_local_cache) {
-            auto disk_space = fs.GetAvailableDiskSpace(x_mooncake_local_cache);
-            if (disk_space.IsValid() && disk_space.GetIndex() > x_min_disk_space) {
-                cached_file = fs.OpenFile(cached_file_path, flags, opener);
-            }
-        }
         return fs.OpenFile(path, flags, opener);
     }
 
@@ -244,7 +238,10 @@ void ColumnstoreTable::Delete(ClientContext &context, unordered_set<row_t> &row_
 
 vector<string> ColumnstoreTable::GetFilePaths(const string &path, const vector<string> &file_names) {
     vector<string> file_paths;
-    if (mooncake_enable_local_cache && FileSystem::IsRemoteFile(path)) {
+
+    // TODO(hjiang): Always enable caching for testing, revert before PR.
+    // if (mooncake_enable_local_cache && FileSystem::IsRemoteFile(path)) {
+    if (true) {
         auto local_fs = FileSystem::CreateLocal();
         for (auto &file_name : file_names) {
             string cached_file_path = x_mooncake_local_cache + file_name;

--- a/src/columnstore/execution/columnstore_scan.cpp
+++ b/src/columnstore/execution/columnstore_scan.cpp
@@ -1,8 +1,11 @@
+#include "columnstore/columnstore_filesystem.hpp"
 #include "columnstore/columnstore_metadata.hpp"
 #include "columnstore/columnstore_statistics.hpp"
 #include "columnstore/columnstore_table.hpp"
 #include "duckdb/catalog/catalog_entry/table_function_catalog_entry.hpp"
+#include "duckdb/common/helper.hpp"
 #include "duckdb/common/multi_file_reader.hpp"
+#include "duckdb/main/client_data.hpp"
 #include "duckdb/main/extension_util.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
 
@@ -135,6 +138,10 @@ unique_ptr<GlobalTableFunctionState> ColumnstoreScanInitGlobal(ClientContext &co
 }
 
 TableFunction ColumnstoreTable::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) {
+    // Use read-optimized filesystem for scan operations.
+    context.client_data->client_file_system =
+        WrapColumnstoreReadCacheFileSystem(std::move(context.client_data->client_file_system));
+
     auto file_names = metadata->DataFilesSearch(oid, &context, &path, &columns);
     auto file_paths = GetFilePaths(path, file_names);
     if (file_paths.empty()) {
@@ -148,6 +155,7 @@ TableFunction ColumnstoreTable::GetScanFunction(ClientContext &context, unique_p
     columnstore_scan.get_multi_file_reader = ColumnstoreScanMultiFileReader::Create;
 
     vector<Value> values;
+    values.reserve(file_paths.size());
     for (auto &file_path : file_paths) {
         values.push_back(Value(file_path));
     }

--- a/src/utils/meta.h
+++ b/src/utils/meta.h
@@ -1,0 +1,11 @@
+// A few macro utils.
+
+#pragma once
+
+// Need to have two macro invocation to allow [x] and [y] to be replaced.
+#define __MOONCAKE_CONCAT(x, y) x##y
+
+#define MOONCAKE_CONCAT(x, y) __MOONCAKE_CONCAT(x, y)
+
+// Macros which gets unique variable name by suffix line number.
+#define MOONCAKE_UNIQUE_VARIABLE(base) MOONCAKE_CONCAT(base, __LINE__)

--- a/src/utils/scope_guard.h
+++ b/src/utils/scope_guard.h
@@ -1,0 +1,63 @@
+// SCOPE_EXIT is used to execute a series of registered functions when it goes
+// out of scope.
+// For details, refer to Andrei Alexandrescu's CppCon 2015 talk "Declarative
+// Control Flow"
+//
+// Examples:
+//   void Function() {
+//     FILE* fp = fopen("my_file.txt", "r");
+//     SCOPE_EXIT { fclose(fp); };
+//     // Do something.
+//   }  // fp will be closed at exit, or pre-emptively if function is early returned due to failure in the middle.
+
+#pragma once
+
+#include <functional>
+#include <utility>
+
+#include "utils/meta.h"
+
+namespace duckdb {
+
+class ScopeGuard {
+private:
+    using Func = std::function<void()>;
+
+public:
+    ScopeGuard() : func_([]() {}) {}
+    explicit ScopeGuard(Func &&func) : func_(std::forward<Func>(func)) {}
+    ~ScopeGuard() noexcept {
+        func_();
+    }
+
+    // Register a new function to be invoked at destruction.
+    // Execution will be performed at the reversed order they're registered.
+    ScopeGuard &operator+=(Func &&another_func) {
+        Func cur_func = std::move(func_);
+        func_ = [cur_func = std::move(cur_func), another_func = std::move(another_func)]() {
+            // Executed in the reverse order functions are registered.
+            another_func();
+            cur_func();
+        };
+        return *this;
+    }
+
+private:
+    Func func_;
+};
+
+namespace internal {
+
+using ScopeGuardFunc = std::function<void()>;
+
+// Constructs a scope guard that calls 'fn' when it exits.
+enum class ScopeGuardOnExit {};
+inline auto operator+(ScopeGuardOnExit /*unused*/, ScopeGuardFunc fn) {
+    return ScopeGuard{std::move(fn)};
+}
+
+} // namespace internal
+
+} // namespace duckdb
+
+#define SCOPE_EXIT auto MOONCAKE_UNIQUE_VARIABLE(SCOPE_EXIT_TEMP_EXIT) = duckdb::internal::ScopeGuardOnExit{} + [&]()


### PR DESCRIPTION
This PR enforces all local access to be read cached, which is used for manual testing, I checked the functionality in two ways:
- Manually execute a set of SQL statements, including table creation, deletion; row insertion, deletion, update, query; and verify all results are correct;
- `make installcheck` to make sure existing SQL testcases all pass;
- Check all files under cache folder are of the same content, as the original data file via `diff`